### PR TITLE
MAP-2664: refactor two routes from an array to separate functions as app insights not being submitted correctly. Also reinstate husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+NODE_ENV=dev && node_modules/.bin/lint-staged && npm run typecheck && npm test

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -27,10 +27,8 @@ export default function establishmentRollRouter(services: Services): Router {
   get('/', establishmentRollController.getEstablishmentRoll())
   get('/locations/', establishmentRollController.getEstablishmentRoll(true))
 
-  get(
-    ['/wing/:wingId/landing/:landingId', '/wing/:wingId/spur/:spurId/landing/:landingId'],
-    establishmentRollController.getEstablishmentRollForLanding(),
-  )
+  get('/wing/:wingId/landing/:landingId', establishmentRollController.getEstablishmentRollForLanding())
+  get('/wing/:wingId/spur/:spurId/landing/:landingId', establishmentRollController.getEstablishmentRollForLanding())
   get('/arrived-today', establishmentRollController.getArrivedToday())
   get('/out-today', establishmentRollController.getOutToday())
   get('/en-route', establishmentRollController.getEnRoute())


### PR DESCRIPTION
This addresses a minor issue where an array of url paths were being submitted to app insights. 

![Screenshot 2025-03-06 at 12 16 22](https://github.com/user-attachments/assets/100ee7f9-59f3-4370-926f-1bbbcde08f34)
