### PR TITLE
MAPB-164: e-roll table column headings, subheadings and width

### DIFF
--- a/assets/scss/pages/_establishment-roll.scss
+++ b/assets/scss/pages/_establishment-roll.scss
@@ -111,5 +111,22 @@
         border-top: 1px solid govuk-colour('black', $variant: 'tint-80');
       }
     }
+
+    &__header-support {
+      display: block;
+      @include govuk-font($size: 16, $weight: regular);
+    }
+
+    .column-width-l {
+      width: 200px;
+    }
+
+    .column-width-m {
+      width: 150px;
+    }
+
+    .column-width-s {
+      width: 100px;
+    }
   }
 }

--- a/server/views/pages/establishmentRoll.njk
+++ b/server/views/pages/establishmentRoll.njk
@@ -127,13 +127,28 @@
     <table class="govuk-table establishment-roll__table">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header"></th>
-                <th scope="col" class="govuk-table__header">Beds in use</th>
-                <th scope="col" class="govuk-table__header">Currently in cell</th>
-                <th scope="col" class="govuk-table__header">Currently out</th>
-                <th scope="col" class="govuk-table__header">{{ capacityLabel }}</th>
-                <th scope="col" class="govuk-table__header">Net vacancies</th>
-                <th scope="col" class="govuk-table__header">Out of order</th>
+                <th scope="col" class="govuk-table__header column-width-l">Location</th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                  Beds in use
+                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                  Currently in
+                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed and on site</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                  Currently out
+                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed and off-site</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                  {{ capacityLabel }}
+                  <span class="establishment-roll__table__header-support">Total beds minus inactive cells</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                  Beds available
+                  <span class="establishment-roll__table__header-support">Working capacity minus beds in use</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-s">Inactive cells</th>
             </tr>
         </thead>
         <tbody class="govuk-table__body">


### PR DESCRIPTION
MAPB-164: e-roll table headings and width

In line with design:

- adjusted headings to new values
- added subheading as supporting text using a `span` tag, styling it to sit under each respective heading. Used our font mixin to get the required size and weight
- adjusted column widths to match design, which also prevents text in the first column (location) from wrapping as a result of the new subheadings. Created custom width override classes of small, medium and large for each column. These are preferred widths so text will still wrap on smaller screens