### PR TITLE
MAPB-164: beds available subheading conditional added 

### DIFF
--- a/server/views/pages/establishmentRoll.njk
+++ b/server/views/pages/establishmentRoll.njk
@@ -129,24 +129,26 @@
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header column-width-l">Location</th>
                 <th scope="col" class="govuk-table__header column-width-m">
-                  Beds in use
-                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed</span>
+                    Beds in use
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed</span>
                 </th>
                 <th scope="col" class="govuk-table__header column-width-m">
-                  Currently in
-                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed and on site</span>
+                    Currently in
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed and on site</span>
                 </th>
                 <th scope="col" class="govuk-table__header column-width-m">
-                  Currently out
-                  <span class="establishment-roll__table__header-support">Prisoners allocated a bed and off-site</span>
+                    Currently out
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed and off-site</span>
                 </th>
                 <th scope="col" class="govuk-table__header column-width-m">
-                  {{ capacityLabel }}
-                  <span class="establishment-roll__table__header-support">Total beds minus inactive cells</span>
+                    {{ capacityLabel }}
+                    <span class="establishment-roll__table__header-support">Total beds minus inactive cells</span>
                 </th>
                 <th scope="col" class="govuk-table__header column-width-m">
-                  Beds available
-                  <span class="establishment-roll__table__header-support">Working capacity minus beds in use</span>
+                    Beds available
+                    {% if useWorkingCapacity %}
+                        <span class="establishment-roll__table__header-support">Working capacity minus beds in use</span>
+                    {% endif %} }}
                 </th>
                 <th scope="col" class="govuk-table__header column-width-s">Inactive cells</th>
             </tr>


### PR DESCRIPTION
MAPB-164: the subheading for the 'Beds available' column `Working capacity minus beds in use` won't show for prisons using operational capacity, this will help avoid any potential confusion