### PR TITLE
MAPB-443: Establishment roll feature flags

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,3 +1,4 @@
+import superagent from 'superagent'
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import auth from './integration_tests/mockApis/auth'
@@ -6,6 +7,19 @@ import locations from './integration_tests/mockApis/locations'
 import prison from './integration_tests/mockApis/prison'
 import prisonerSearch from './integration_tests/mockApis/prisonerSearch'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
+
+async function setFeatureFlag(flags: Record<string, boolean>): Promise<null> {
+  const query = Object.fromEntries(Object.entries(flags).map(([key, val]) => [key, val ? 'enabled' : 'disabled']))
+  await superagent.get('http://localhost:3007/set-feature-flag').query(query)
+
+  return null
+}
+
+async function resetFeatureFlags(): Promise<null> {
+  await superagent.get('http://localhost:3007/reset-feature-flags')
+
+  return null
+}
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -21,6 +35,8 @@ export default defineConfig({
     setupNodeEvents(on) {
       on('task', {
         reset: resetStubs,
+        setFeatureFlag,
+        resetFeatureFlags,
         ...auth,
         ...feComponents,
         ...locations,

--- a/feature.env
+++ b/feature.env
@@ -16,3 +16,4 @@ PRISONER_SEARCH_API_URL=http://localhost:9091/prisoner-search
 PRISONER_PROFILE_URL=http://localhost:9091/prisoner-profile
 COMPONENT_API_URL=http://localhost:9091/frontend-components
 ENVIRONMENT_NAME=dev
+FEATURE_FLIPPER_ENABLED=true

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,3 +31,5 @@ generic-service:
     AUDIT_ENABLED: "false"
 
     TAG_MANAGER_CONTAINER_ID: "G-65CM9HZPT0"
+
+    FLAG_E_ROLL_REBUILD: enabled

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,4 +32,4 @@ generic-service:
 
     TAG_MANAGER_CONTAINER_ID: "G-65CM9HZPT0"
 
-    FLAG_E_ROLL_REBUILD: disabled
+    FLAG_E_ROLL_REBUILD: enabled

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -33,4 +33,3 @@ generic-service:
     TAG_MANAGER_CONTAINER_ID: "G-65CM9HZPT0"
 
     FLAG_E_ROLL_REBUILD: disabled
-    FEATURE_FLIPPER_ENABLED: true

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,4 +32,5 @@ generic-service:
 
     TAG_MANAGER_CONTAINER_ID: "G-65CM9HZPT0"
 
-    FLAG_E_ROLL_REBUILD: enabled
+    FLAG_E_ROLL_REBUILD: disabled
+    FEATURE_FLIPPER_ENABLED: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -33,4 +33,3 @@ generic-service:
     TAG_MANAGER_CONTAINER_ID: "G-65S5RRM7NY"
 
     FLAG_E_ROLL_REBUILD: disabled
-    FEATURE_FLIPPER_ENABLED: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -31,3 +31,5 @@ generic-service:
     AUDIT_ENABLED: "false"
 
     TAG_MANAGER_CONTAINER_ID: "G-65S5RRM7NY"
+
+    FLAG_E_ROLL_REBUILD: disabled

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -33,3 +33,4 @@ generic-service:
     TAG_MANAGER_CONTAINER_ID: "G-65S5RRM7NY"
 
     FLAG_E_ROLL_REBUILD: disabled
+    FEATURE_FLIPPER_ENABLED: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,7 +37,6 @@ generic-service:
     TAG_MANAGER_CONTAINER_ID: "G-6RRVY5L6EF"
 
     FLAG_E_ROLL_REBUILD: disabled
-    FEATURE_FLIPPER_ENABLED: false
 
   generic-prometheus-alerts:
     alertSeverity: move-a-prisoner-alerts-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -36,5 +36,7 @@ generic-service:
 
     TAG_MANAGER_CONTAINER_ID: "G-6RRVY5L6EF"
 
+    FLAG_E_ROLL_REBUILD: disabled
+
   generic-prometheus-alerts:
     alertSeverity: move-a-prisoner-alerts-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,6 +37,7 @@ generic-service:
     TAG_MANAGER_CONTAINER_ID: "G-6RRVY5L6EF"
 
     FLAG_E_ROLL_REBUILD: disabled
+    FEATURE_FLIPPER_ENABLED: false
 
   generic-prometheus-alerts:
     alertSeverity: move-a-prisoner-alerts-prod

--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -38,4 +38,38 @@ context('Index', () => {
       Page.verifyOnPage(IndexPage)
     })
   })
+
+  context('Establishment Roll feature flag', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('resetFeatureFlags')
+      cy.task('stubUserCaseLoads')
+      cy.task('stubUserLocations')
+      cy.task('stubActivePrisons', { activeAgencies: ['LEI'] })
+      cy.task('stubLocationPrisonRollCount')
+      cy.task('stubPrisonConfiguration')
+      cy.setupUserAuth()
+      cy.setupUserCaseloads()
+    })
+
+    it('Loads the rebuilt page with cards when eRollRebuild is enabled', () => {
+      cy.task('setFeatureFlag', { eRollRebuild: true })
+      cy.visit('/sign-in')
+      cy.signIn()
+
+      cy.contains('h1', 'Establishment roll with cards for').should('exist')
+      cy.contains('h3', 'This is the page when feature flags are on').should('exist')
+      cy.get('[data-qa="unlock-roll-card"]').should('exist')
+    })
+
+    it('loads the original page after resetting feature flags', () => {
+      cy.task('setFeatureFlag', { eRollRebuild: true })
+      cy.task('resetFeatureFlags')
+      cy.visit('/sign-in')
+      cy.signIn()
+
+      cy.contains('h1', 'Establishment roll for').should('exist')
+      cy.get('[data-qa="unlock-roll"]').should('exist')
+    })
+  })
 })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -23,6 +23,7 @@ export declare global {
       services?: Services
       middleware?: Record
       logout(done: (err: unknown) => void): void
+      featureFlags?: (typeof config)['featureFlags']
     }
 
     interface Locals {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
 import { HmppsUser } from '../../interfaces/hmppsUser'
 import { Services } from '../../services'
+import config from '../../config'
 
 export declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import setUpEnvironmentName from './middleware/setUpEnvironmentName'
 import setUpPageNotFound from './middleware/setUpPageNotFound'
 
 import { ensureActiveCaseLoadSet } from './middleware/ensureActiveCaseLoadSet'
+import setUpFeatureFlags from './middleware/setUpFeatureFlags'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -41,6 +42,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   setUpEnvironmentName(app)
   nunjucksSetup(app)
+  app.use(setUpFeatureFlags())
   app.use(setUpAuthentication())
   app.use(authorisationMiddleware(['ROLE_PRISON']))
   app.use(setUpCsrf())

--- a/server/config.ts
+++ b/server/config.ts
@@ -144,4 +144,7 @@ export default {
   analytics: {
     tagManagerContainerId: get('TAG_MANAGER_CONTAINER_ID', ''),
   },
+  featureFlags: {
+    eRollRebuild: get('FLAG_E_ROLL_REBUILD', 'disabled') === 'enabled',
+  },
 }

--- a/server/controllers/establishmentRollController.test.ts
+++ b/server/controllers/establishmentRollController.test.ts
@@ -221,4 +221,65 @@ describe('EstablishmentRollController', () => {
       })
     })
   })
+
+  describe('getEstablishmentRoll with feature flag rendering', () => {
+    it('renders the establishmentRollWithCards page when the eRollRebuild flag is true', async () => {
+      establishmentRollService.getEstablishmentRollCounts.mockResolvedValue({ todayStats: {}, totals: {}, wings: [] })
+      establishmentRollService.isResiLocationServiceActive.mockResolvedValue(false)
+
+      const controller = new EstablishmentRollController(
+        establishmentRollService as unknown as EstablishmentRollService,
+        movementsService as unknown as MovementsService,
+        locationService as unknown as LocationService,
+      )
+
+      const req = mockReq()
+      const res = mockRes()
+      const next = mockNext()
+      req.featureFlags = { eRollRebuild: true }
+
+      await controller.getEstablishmentRoll(false)(req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/establishmentRollWithCards', expect.any(Object))
+    })
+
+    it('renders the establishmentRoll page when the eRollRebuild flag is false', async () => {
+      establishmentRollService.getEstablishmentRollCounts.mockResolvedValue({ todayStats: {}, totals: {}, wings: [] })
+      establishmentRollService.isResiLocationServiceActive.mockResolvedValue(false)
+
+      const controller = new EstablishmentRollController(
+        establishmentRollService as unknown as EstablishmentRollService,
+        movementsService as unknown as MovementsService,
+        locationService as unknown as LocationService,
+      )
+
+      const req = mockReq()
+      const res = mockRes()
+      const next = mockNext()
+      req.featureFlags = { eRollRebuild: false }
+
+      await controller.getEstablishmentRoll(false)(req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/establishmentRoll', expect.any(Object))
+    })
+
+    it('renders the establishmentRoll page when the eRollRebuild flag is not present', async () => {
+      establishmentRollService.getEstablishmentRollCounts.mockResolvedValue({ todayStats: {}, totals: {}, wings: [] })
+      establishmentRollService.isResiLocationServiceActive.mockResolvedValue(false)
+
+      const controller = new EstablishmentRollController(
+        establishmentRollService as unknown as EstablishmentRollService,
+        movementsService as unknown as MovementsService,
+        locationService as unknown as LocationService,
+      )
+
+      const req = mockReq()
+      const res = mockRes()
+      const next = mockNext()
+
+      await controller.getEstablishmentRoll(false)(req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/establishmentRoll', expect.any(Object))
+    })
+  })
 })

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -25,7 +25,12 @@ export default class EstablishmentRollController {
       const useLocationsApi =
         forceUseLocationsApi ||
         (await this.establishmentRollService.isResiLocationServiceActive(clientToken, user.activeCaseLoadId))
-      res.render('pages/establishmentRoll', {
+      let pageName = 'pages/establishmentRoll'
+      if (req.featureFlags?.eRollRebuild) {
+        pageName = 'pages/establishmentRollWithCards'
+      }
+
+      res.render(pageName, {
         establishmentRollCounts: establishmentRollCounts || null,
         date: new Date(),
         useWorkingCapacity: useLocationsApi,

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -25,6 +25,7 @@ export default class EstablishmentRollController {
       const useLocationsApi =
         forceUseLocationsApi ||
         (await this.establishmentRollService.isResiLocationServiceActive(clientToken, user.activeCaseLoadId))
+      // Temporary page, once signed off this will be merged into the existing establishmentRoll page
       let pageName = 'pages/establishmentRoll'
       if (req.featureFlags?.eRollRebuild) {
         pageName = 'pages/establishmentRollWithCards'

--- a/server/middleware/setUpFeatureFlags.ts
+++ b/server/middleware/setUpFeatureFlags.ts
@@ -1,0 +1,35 @@
+import type { Router } from 'express'
+import express from 'express'
+import config from '../config'
+
+const router = express.Router()
+
+export default function setUpFeatureFlags(): Router {
+  const flags = { ...config.featureFlags }
+
+  router.use((req, _res, next) => {
+    req.featureFlags = flags
+    next()
+  })
+
+  if (process.env.FEATURE_FLIPPER_ENABLED === 'true') {
+    router.get('/set-feature-flag', (req, res) => {
+      ;(Object.entries(req.query) as [keyof typeof flags, string][]).forEach(([key, val]) => {
+        flags[key] = val === 'enabled'
+      })
+      res.sendStatus(200)
+    })
+
+    router.get('/reset-feature-flags', (_req, res) => {
+      Object.keys(flags).forEach((key: keyof typeof flags) => delete flags[key])
+
+      Object.entries(config.featureFlags).forEach(([key, val]: [keyof typeof flags, boolean]) => {
+        flags[key] = val
+      })
+
+      res.sendStatus(200)
+    })
+  }
+
+  return router
+}

--- a/server/views/pages/establishmentRollWithCards.njk
+++ b/server/views/pages/establishmentRollWithCards.njk
@@ -1,0 +1,190 @@
+{% extends "../partials/layout.njk" %}
+{% from "../macros/printLink.njk" import printLink %}
+{% from "../macros/establishmentRollStat.njk" import establishmentRollStat %}
+
+{% set mainClasses = "govuk-body govuk-main-wrapper--auto-spacing" %}
+{% set todayStats = establishmentRollCounts.todayStats %}
+{% set totals = establishmentRollCounts.totals %}
+{% set wings = establishmentRollCounts.wings %}
+{% set capacityLabel = "Working capacity" if useWorkingCapacity else "Operational capacity" %}
+{% set breadCrumbs = [
+    {
+        text: 'Digital Prison Services',
+        href:  dpsUrl
+    }
+] %}
+
+{% macro blockRow(block, type, wing, spur, lastInGroup) %}
+    <tr class="govuk-table__row establishment-roll__table__{{ "spur" if type==="SPUR" else ("landing" if type==="LANDING" else "wing") }}-row {{ 'last-in-group' if lastInGroup else '' }}"
+        id="{{ block.locationId }}"
+        {% if wing %}data-wing-id="{{ wing }}" {% endif %}
+    >
+        <td class="govuk-table__cell">
+            {% if type === "LANDING" %}
+                <a class="govuk-link" href="/wing/{{ wing }}/{{ "spur/"+spur+"/" if spur }}landing/{{ block.locationId }}">{{ block.localName or block.locationCode }}</a>
+            {% else %}
+                {{ block.localName or block.locationCode }}
+            {% endif %}
+        </td>
+        <td class="govuk-table__cell">{{ block.rollCount.bedsInUse }}</td>
+        <td class="govuk-table__cell">{{ block.rollCount.currentlyInCell }}</td>
+        <td class="govuk-table__cell">
+            {% if block.rollCount.currentlyOut > 0 %}
+                <a class="govuk-link" href="/{{block.locationId}}/currently-out">{{block.rollCount.currentlyOut}}</a>
+            {% else %} 0 {% endif %}
+        </td>
+        <td class="govuk-table__cell">{{ block.rollCount.workingCapacity }}</td>
+        <td class="govuk-table__cell">{{ block.rollCount.netVacancies }}</td>
+        <td class="govuk-table__cell">{{ block.rollCount.outOfOrder }}</td>
+    </tr>
+{% endmacro %}
+
+{% block content %}
+<div class="govuk-width-container govuk-!-margin-top-8">
+    <div class="govuk-!-margin-bottom-6">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Establishment roll with cards for {{ date | formatDate('full') }}</h1>
+        {{ printLink(align = "right") }}
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "Today’s unlock roll",
+                    value = todayStats.unlockRoll,
+                    qaTag = "unlock-roll"
+                )
+            }}
+        </div>
+
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "Current population",
+                    value = todayStats.currentRoll,
+                    qaTag = "current-roll"
+                )
+            }}
+        </div>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-2">
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "Arrived today",
+                    value = todayStats.inToday,
+                    href = "/arrived-today",
+                    qaTag = "in-today"
+                )
+            }}
+        </div>
+
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "In reception",
+                    value = todayStats.unassignedIn,
+                    href = "/in-reception",
+                    qaTag = "unassigned-in"
+                )
+            }}
+        </div>
+
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "Still to arrive",
+                    value = todayStats.enroute,
+                    href = "/en-route",
+                    qaTag = "enroute"
+                )
+            }}
+        </div>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-9">
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "Out today",
+                    value = todayStats.outToday,
+                    href = "/out-today",
+                    qaTag = "out-today"
+                )
+            }}
+        </div>
+
+        <div class="govuk-grid-column-one-third">
+            {{
+                establishmentRollStat(
+                    heading = "No cell allocated",
+                    value = todayStats.noCellAllocated,
+                    href = "/no-cell-allocated",
+                    qaTag = "no-cell-allocated"
+                )
+            }}
+        </div>
+    </div>
+
+    <table class="govuk-table establishment-roll__table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header column-width-l">Location</th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                    Beds in use
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                    Currently in
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed and on site</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                    Currently out
+                    <span class="establishment-roll__table__header-support">Prisoners allocated a bed and off-site</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                    {{ capacityLabel }}
+                    <span class="establishment-roll__table__header-support">Total beds minus inactive cells</span>
+                </th>
+                <th scope="col" class="govuk-table__header column-width-m">
+                    Beds available
+                    {% if useWorkingCapacity %}
+                        <span class="establishment-roll__table__header-support">Working capacity minus beds in use</span>
+                    {% endif %}
+                </th>
+                <th scope="col" class="govuk-table__header column-width-s">Inactive cells</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for wing in wings %}
+                {{ blockRow(block=wing) }}
+
+                {% for subLocation in wing.subLocations %}
+                    {% set style = 'SPUR' if subLocation.subLocations.length else 'LANDING' %}
+
+                    {% if style === 'SPUR' %}
+                        {{ blockRow(block=subLocation, type='SPUR', wing=wing.locationId) }}
+                        {% for landing in subLocation.subLocations %}
+                            {{ blockRow(block=landing, type='LANDING', wing=wing.locationId, spur=subLocation.locationId, lastInGroup=loop.index === subLocation.subLocations.length) }}
+                        {% endfor %}
+                    {% else %}
+                        {{ blockRow(block=subLocation, type='LANDING', wing=wing.locationId, lastInGroup=loop.index === wing.subLocations.length) }}
+                    {% endif %}
+                {% endfor %}
+
+            {% endfor %}
+            <tr id="roll-table-totals-row" class="govuk-table__row">
+                <td class="govuk-table__cell govuk-!-font-weight-bold">Totals</td>
+                <td class="govuk-table__cell">{{ totals.bedsInUse }}</td>
+                <td class="govuk-table__cell">{{ totals.currentlyInCell }}</td>
+                <td class="govuk-table__cell">
+                    {% if totals.currentlyOut > 0 %}
+                        <a class="govuk-link" href="/total-currently-out">{{totals.currentlyOut}}</a>
+                    {% else %} 0 {% endif %}
+                </td>
+                <td class="govuk-table__cell">{{ totals.workingCapacity }}</td>
+                <td class="govuk-table__cell">{{ totals.netVacancies }}</td>
+                <td class="govuk-table__cell">{{ totals.outOfOrder }}</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/server/views/pages/establishmentRollWithCards.njk
+++ b/server/views/pages/establishmentRollWithCards.njk
@@ -49,9 +49,9 @@
         <div class="govuk-grid-column-one-third">
             {{
                 establishmentRollStat(
-                    heading = "Today’s unlock roll",
+                    heading = "Card test for Today’s unlock roll",
                     value = todayStats.unlockRoll,
-                    qaTag = "unlock-roll"
+                    qaTag = "unlock-roll-card"
                 )
             }}
         </div>
@@ -61,7 +61,7 @@
                 establishmentRollStat(
                     heading = "Current population",
                     value = todayStats.currentRoll,
-                    qaTag = "current-roll"
+                    qaTag = "current-roll-card"
                 )
             }}
         </div>
@@ -73,7 +73,7 @@
                     heading = "Arrived today",
                     value = todayStats.inToday,
                     href = "/arrived-today",
-                    qaTag = "in-today"
+                    qaTag = "in-today-card"
                 )
             }}
         </div>
@@ -84,7 +84,7 @@
                     heading = "In reception",
                     value = todayStats.unassignedIn,
                     href = "/in-reception",
-                    qaTag = "unassigned-in"
+                    qaTag = "unassigned-in-card"
                 )
             }}
         </div>
@@ -95,7 +95,7 @@
                     heading = "Still to arrive",
                     value = todayStats.enroute,
                     href = "/en-route",
-                    qaTag = "enroute"
+                    qaTag = "enroute-card"
                 )
             }}
         </div>
@@ -107,7 +107,7 @@
                     heading = "Out today",
                     value = todayStats.outToday,
                     href = "/out-today",
-                    qaTag = "out-today"
+                    qaTag = "out-today-card"
                 )
             }}
         </div>
@@ -118,10 +118,14 @@
                     heading = "No cell allocated",
                     value = todayStats.noCellAllocated,
                     href = "/no-cell-allocated",
-                    qaTag = "no-cell-allocated"
+                    qaTag = "no-cell-allocated-card"
                 )
             }}
         </div>
+    </div>
+
+    <div class="govuk-!-margin-bottom-6">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-0">This is the page when feature flags are on</h3>
     </div>
 
     <table class="govuk-table establishment-roll__table">


### PR DESCRIPTION
Feature flag functionality set up for e-roll. 

Flags are loaded from the environment config and attached to each request by the `setUpFeatureFlags` middleware.

The `eRollRebuild` flag is set to true in `dev` so the new variant can be viewed there. The feature flipper endpoints (`/set-feature-flag`, `/reset-feature-flags`) are for integration tests only. 

I've set up an alternate view of the e-roll home page, and the controller renders the relevant template depending on if the feature flag is enabled. I will move the summary card work from **MAPB-160** to this flagged view once this PR has been approved.

Please note: the alternate page is temporary and is intended to replace the current e-roll home page once signed off.

**`Updates`**

Added `setFeatureFlag` and `resetFeatureFlags` to Cypress config.

Removed feature flipper from helm and moved to feature.env for integration testing.

Added integration tests for when the flag is set to true or when it is reset.

Added unit tests to check the right template is rendered depending on the feature flag.

