### PR TITLE
MAPB-160: print layout changes for rebuilt page

### DIFF
--- a/assets/scss/pages/_establishment-roll.scss
+++ b/assets/scss/pages/_establishment-roll.scss
@@ -57,8 +57,6 @@
           border-bottom: none;
         }
       }
-
-
     }
 
     &__landing-row {
@@ -83,7 +81,6 @@
           font-size: 14px !important;
         }
       }
-
     }
 
     &__spur-row {
@@ -142,6 +139,12 @@
   flex-wrap: wrap;
   gap: 30px;
   margin: govuk-spacing(6) 0;
+
+  @media print {
+    flex-wrap: nowrap;
+    gap: 10px;
+    margin: govuk-spacing(2) 0;
+  }
 }
 
 .establishment-roll-card {
@@ -162,5 +165,46 @@
   &__count {
     @include govuk-font($size: 48, $weight: bold);
     margin-top: auto;
+  }
+
+  @media print {
+    width: calc((100% - 30px) / 4);
+    height: 100px;
+    padding: 10px;
+    break-inside: avoid;
+  }
+}
+
+@media print {
+  .establishment-roll {
+    &-card {
+      h3 {
+        font-size: 10pt !important;
+        line-height: 1.2;
+        margin-bottom: 2pt;
+      }
+
+      &__description {
+        font-size: 8pt !important;
+        line-height: 1.2;
+      }
+
+      &__count {
+        font-size: 16pt !important;
+        line-height: 1.1;
+      }
+    }
+
+    &__table {
+      th.govuk-table__header {
+        font-size: 9pt !important;
+        line-height: 1.2;
+      }
+
+      &__header-support {
+        font-size: 8pt !important;
+        line-height: 1.2;
+      }
+    }
   }
 }

--- a/server/views/macros/printLink.njk
+++ b/server/views/macros/printLink.njk
@@ -1,6 +1,6 @@
 {% macro printLink(linkText = 'Print this page', align = "left") %}
     <div {% if align %} class="text-align-{{ align }}" {% endif %}>
-        <a href="#" class="govuk-link print-link hmpps-print-link govuk-!-display-none-print govuk-!-font-size-16 govuk-!-margin-bottom-0">
+        <a href="#" class="govuk-link print-link hmpps-print-link govuk-!-display-none-print govuk-!-font-size-19 govuk-!-margin-bottom-0">
             {{ linkText }}
         </a>
     </div>


### PR DESCRIPTION
- tidy up
- corrected print layout so that the print preview matches the layout on screen
- increased print hyperlink to size in design