### PR TITLE
MAPB-160: table and print styling changes

### DIFF
--- a/assets/scss/pages/_establishment-roll.scss
+++ b/assets/scss/pages/_establishment-roll.scss
@@ -125,6 +125,10 @@
     .column-width-s {
       width: 100px;
     }
+
+    #roll-table-totals-row {
+      font-weight: bold;
+    }
   }
 
   &__before-content {

--- a/server/views/pages/establishmentRollWithCards.njk
+++ b/server/views/pages/establishmentRollWithCards.njk
@@ -13,6 +13,7 @@
         href:  dpsUrl
     }
 ] %}
+{% set showPrintLink = true %}
 
 {% macro blockRow(block, type, wing, spur, lastInGroup) %}
     <tr class="govuk-table__row establishment-roll__table__{{ "spur" if type == "SPUR" else ("landing" if type == "LANDING" else "wing") }}-row {{ 'last-in-group' if lastInGroup else '' }}"
@@ -38,16 +39,6 @@
         <td class="govuk-table__cell">{{ block.rollCount.outOfOrder }}</td>
     </tr>
 {% endmacro %}
-
-{% block beforeContent %}
-    <div class="establishment-roll__before-content">
-        {{ govukBreadcrumbs({
-            items: breadCrumbs | default([]),
-            classes: 'govuk-!-display-none-print'
-        }) }}
-        {{ printLink(align = "right") }}
-    </div>
-{% endblock %}
 
 {% block content %}
 <div class="govuk-width-container govuk-!-margin-top-8">

--- a/server/views/pages/establishmentRollWithCards.njk
+++ b/server/views/pages/establishmentRollWithCards.njk
@@ -1,5 +1,4 @@
 {% extends "../partials/layout.njk" %}
-{% from "../macros/printLink.njk" import printLink %}
 {% from "../macros/establishmentRollStatCard.njk" import establishmentRollStatCard %}
 
 {% set mainClasses = "govuk-body govuk-main-wrapper--auto-spacing" %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "../macros/printLink.njk" import printLink %}
 {% extends "govuk/template.njk" %}
 
 {% block head %}
@@ -50,10 +51,16 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: breadCrumbs | default([]),
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  <div class="establishment-roll__before-content">
+    {{ govukBreadcrumbs({
+      items: breadCrumbs | default([]),
+      classes: 'govuk-!-display-none-print'
+    }) }}
+
+    {% if showPrintLink %}
+      {{ printLink(align = "right") }}
+    {% endif %}
+  </div>
 {% endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
Implementing some changes after UCD feedback and discussion:

- Roll totals in table now bold. 
- Moved the print link from rebuilt page to layout.njk with a flag `showPrintLink` so we can control whether we set it active on pages. Flag can be removed if we agree to have print option on every page of estab roll