### PR TITLE
MAPB-453 Fix for CSS when running in Safari localhost

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Jira ticket
+
+[MAPB-XXX](https://dsdmoj.atlassian.net/browse/MAPB-XXX)
+
+## Screenshots
+
+<!-- Add screenshots or screen recordings where applicable -->

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -59,6 +59,7 @@ export default function setUpWebSecurity(): Router {
           formAction,
           imgSrc,
           mediaSrc,
+          upgradeInsecureRequests: config.https ? [] : null,
         },
       },
       crossOriginEmbedderPolicy: true,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -22,7 +22,7 @@
     <!-- Google tag (gtag.js) end -->
   {% endif %}
 
-  <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet"/>
+  <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet" nonce="{{ cspNonce }}"/>
 
   <script src="/assets/js/jquery.min.js"></script>
 


### PR DESCRIPTION
## Description

- Helmet's Content Security Policy defaults include the `upgrade-insecure-requests` which was causing localhost to be re-written with `https` preventing it from loading the CSS file when loaded in Safari. Chrome does not enforce the same security which is why the issue doesn't show there. This PR adds a localhost check to disable this.
- Added a PR template - happy to remove if we feel this isn't needed.

## Jira ticket

[MAPB-453](https://dsdmoj.atlassian.net/browse/MAPB-453)

## Screenshots

**Before**
<img width="1728" height="995" alt="Screenshot 2026-06-09 at 15 09 37" src="https://github.com/user-attachments/assets/87fdcad0-c8ea-4c66-91ab-78376834e44a" />

**After**
<img width="1728" height="995" alt="Screenshot 2026-06-09 at 16 22 35" src="https://github.com/user-attachments/assets/10a228eb-ca92-4458-b337-a4cb994a98d4" />



[MAPB-453]: https://dsdmoj.atlassian.net/browse/MAPB-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ