### PR TITLE
MAPB-201 Add CSRA column with return breadcrumb to In reception

### DIFF
--- a/assets/scss/components/_results-table.scss
+++ b/assets/scss/components/_results-table.scss
@@ -23,3 +23,10 @@
       }
     }
 }
+
+// Horizontal stroke between records, but no stroke on the last row's baseline
+.in-reception-roll__table {
+  .govuk-table__body .govuk-table__row:last-child .govuk-table__cell {
+    border-bottom: 0;
+  }
+}

--- a/integration_tests/e2e/inReception.cy.ts
+++ b/integration_tests/e2e/inReception.cy.ts
@@ -81,4 +81,33 @@ context('In reception Page', () => {
       .and('contain', 'returnPath=/in-reception')
       .and('contain', 'redirectPath=/prisoner/A1234AB/csra-history')
   })
+
+  it('makes Name, Date of birth, Time arrived and CSRA sortable but not the other columns', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    // Sortable columns expose aria-sort
+    page.inReceptionHeaders().eq(1).should('have.attr', 'aria-sort') // Name
+    page.inReceptionHeaders().eq(3).should('have.attr', 'aria-sort') // Date of birth
+    page.inReceptionHeaders().eq(4).should('have.attr', 'aria-sort') // Time arrived
+    page.inReceptionHeaders().eq(6).should('have.attr', 'aria-sort') // CSRA
+
+    // Non-sortable columns do not
+    page.inReceptionHeaders().eq(2).should('not.have.attr', 'aria-sort') // Prison number
+    page.inReceptionHeaders().eq(5).should('not.have.attr', 'aria-sort') // Arrived from
+    page.inReceptionHeaders().eq(7).should('not.have.attr', 'aria-sort') // Alert flags
+  })
+
+  it('sorts Date of birth chronologically using the ISO date as the sort value', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    page.inReceptionRows().first().find('td').eq(3).should('have.attr', 'data-sort-value', '1980-01-01')
+  })
+
+  it('applies the govuk-!-font-size-16 override to the body cells', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    page.inReceptionRows().first().find('td').eq(1).should('have.class', 'govuk-!-font-size-16')
+    page.inReceptionRows().first().find('td').eq(3).should('have.class', 'govuk-!-font-size-16')
+    page.inReceptionRows().first().find('td').eq(7).should('have.class', 'govuk-!-font-size-16')
+  })
 })

--- a/integration_tests/e2e/inReception.cy.ts
+++ b/integration_tests/e2e/inReception.cy.ts
@@ -30,15 +30,24 @@ context('In reception Page', () => {
     page.inReceptionRows().first().find('td').eq(3).should('contain.text', '01/01/1980')
     page.inReceptionRows().first().find('td').eq(4).should('contain.text', '11:00')
     page.inReceptionRows().first().find('td').eq(5).should('contain.text', 'Leeds')
-    page.inReceptionRows().first().find('td').eq(6).should('contain.text', '')
+    page.inReceptionRows().first().find('td').eq(6).should('contain.text', 'Standard')
+    page.inReceptionRows().first().find('td').eq(7).should('contain.text', '')
+  })
+
+  it('should display the CSRA level for each prisoner', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+    page.inReceptionRows().should('have.length', 2)
+
+    page.inReceptionRows().first().find('td').eq(6).should('contain.text', 'Standard')
+    page.inReceptionRows().eq(1).find('td').eq(6).should('contain.text', 'High')
   })
 
   it('should display alerts and category if cat A', () => {
     const page = Page.verifyOnPage(InReceptionPage)
     page.inReceptionRows().should('have.length', 2)
 
-    page.inReceptionRows().eq(1).find('td').eq(6).should('contain.text', 'Hidden disability')
-    page.inReceptionRows().eq(1).find('td').eq(6).should('contain.text', 'CAT A')
+    page.inReceptionRows().eq(1).find('td').eq(7).should('contain.text', 'Hidden disability')
+    page.inReceptionRows().eq(1).find('td').eq(7).should('contain.text', 'CAT A')
   })
 
   it('name link returns to the In reception page via the prisoner profile back link', () => {
@@ -55,5 +64,21 @@ context('In reception Page', () => {
       .and('contain', 'service=prison-roll-count')
       .and('contain', 'returnPath=/in-reception')
       .and('contain', 'redirectPath=/prisoner/A1234AB')
+  })
+
+  it('CSRA link goes to the CSRA history page and returns to the In reception page via the back link', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    page
+      .inReceptionRows()
+      .first()
+      .find('td')
+      .eq(6)
+      .find('a')
+      .should('have.attr', 'href')
+      .and('contain', '/save-backlink')
+      .and('contain', 'service=prison-roll-count')
+      .and('contain', 'returnPath=/in-reception')
+      .and('contain', 'redirectPath=/prisoner/A1234AB/csra-history')
   })
 })

--- a/integration_tests/pages/inReception.ts
+++ b/integration_tests/pages/inReception.ts
@@ -6,4 +6,6 @@ export default class InReceptionPage extends Page {
   }
 
   inReceptionRows = (): PageElement => cy.get('table.in-reception-roll__table tbody tr')
+
+  inReceptionHeaders = (): PageElement => cy.get('table.in-reception-roll__table thead th')
 }

--- a/server/test/mocks/prisonerSearchMock.ts
+++ b/server/test/mocks/prisonerSearchMock.ts
@@ -17,6 +17,7 @@ const prisonerSearchMock: Prisoner[] = [
     cellLocation: '1-1-1',
     mostSeriousOffence: '',
     restrictedPatient: false,
+    csra: 'High',
     alerts: [
       {
         alertType: 'Hidden disability',
@@ -43,6 +44,7 @@ const prisonerSearchMock: Prisoner[] = [
     cellLocation: '1-1-1',
     mostSeriousOffence: '',
     restrictedPatient: false,
+    csra: 'Standard',
     alerts: [],
   },
 ]

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -33,6 +33,7 @@
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Date of birth</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Arrived from</th>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Alert flags</th>
                     </tr>
                 </thead>
@@ -46,6 +47,8 @@
                             <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
                             <td class="govuk-table__cell">{{ prisoner.timeArrived | formatTime }}</td>
                             <td class="govuk-table__cell">{{ prisoner.from }}</td>
+                            {% set csraLevel = prisoner.csra or 'None' %}
+                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
                             <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -30,7 +30,7 @@
                         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Picture</span></th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="ascending">Name</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Prison number</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Date of birth</th>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Date of birth</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Arrived from</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
@@ -42,14 +42,14 @@
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}" ><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
-                            <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
-                            <td class="govuk-table__cell">{{ prisoner.timeArrived | formatTime }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.from }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisonerName }}" ><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.prisonerNumber }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisoner.dateOfBirth }}">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.timeArrived | formatTime }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
                             {% set csraLevel = prisoner.csra or 'None' %}
-                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}
 


### PR DESCRIPTION
## MAPB-201 — Return breadcrumb from CSRA service to the In reception page

[MAPB-201](https://dsdmoj.atlassian.net/browse/MAPB-201) · also delivers [MAPB-235](https://dsdmoj.atlassian.net/browse/MAPB-235)

### What
Adds a **CSRA** column to the In reception page. Each prisoner's latest CSRA level (or `None`) is rendered as a hyperlink to their CSRA history in the prisoner profile. The link routes through the prisoner profile `/save-backlink` endpoint, so the CSRA history page shows a **"Back to In reception"** link that returns the user to the roll-count In reception page they came from.

`In reception > CSRA hyperlink > Prisoner CSRA history > In reception`

### Why
So users processing prisoners in reception can view a prisoner's CSRA history and return directly to where they were, without losing navigation steps.

### How it works
The link target is:
```
{prisonerProfile}/save-backlink?service=prison-roll-count&backLinkText=Back to In reception&returnPath=/in-reception&redirectPath=/prisoner/{number}/csra-history
```
`prison-roll-count` is already a registered back-link service in the prisoner profile, and its layout renders the stored `userBackLink` on every page — including CSRA history — so **no prisoner-profile changes are required**. This mirrors the pattern used for the prisoner-name link in MAPB-243.

### Notes
- Scoped to the CSRA column + link only — not the pagination / "Print this page" / "Relevant alerts" rename shown in the wider design mockup.
- The In reception page has no server-side pagination and `returnPath` returns to the exact same page. Sorting is client-side (`moj-sortable-table`), so the sort selection resets on return — same behaviour as the existing name link.

### Testing
- `tsc` (app + integration_tests) and `eslint` pass.
- `jest` unit suite passes.
- Cypress `inReception.cy.ts` passes (6 tests), including assertions that the CSRA link carries the correct `/save-backlink` query and `redirectPath=/prisoner/{number}/csra-history`.

> Stacked on #176 (MAPB-243). Base will auto-retarget to `main` once that merges.

[MAPB-201]: https://dsdmoj.atlassian.net/browse/MAPB-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAPB-235]: https://dsdmoj.atlassian.net/browse/MAPB-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ