### PR TITLE
MAPB-131 Amend the In reception page (sorting and styling)

### DIFF
--- a/assets/scss/components/_results-table.scss
+++ b/assets/scss/components/_results-table.scss
@@ -23,3 +23,10 @@
       }
     }
 }
+
+// Horizontal stroke between records, but no stroke on the last row's baseline
+.in-reception-roll__table {
+  .govuk-table__body .govuk-table__row:last-child .govuk-table__cell {
+    border-bottom: 0;
+  }
+}

--- a/integration_tests/e2e/inReception.cy.ts
+++ b/integration_tests/e2e/inReception.cy.ts
@@ -81,4 +81,33 @@ context('In reception Page', () => {
       .and('contain', 'returnPath=/in-reception')
       .and('contain', 'redirectPath=/prisoner/A1234AB/csra-history')
   })
+
+  it('makes Name, Date of birth, Time arrived and CSRA sortable but not the other columns', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    // Sortable columns expose aria-sort
+    page.inReceptionHeaders().eq(1).should('have.attr', 'aria-sort') // Name
+    page.inReceptionHeaders().eq(3).should('have.attr', 'aria-sort') // Date of birth
+    page.inReceptionHeaders().eq(4).should('have.attr', 'aria-sort') // Time arrived
+    page.inReceptionHeaders().eq(6).should('have.attr', 'aria-sort') // CSRA
+
+    // Non-sortable columns do not
+    page.inReceptionHeaders().eq(2).should('not.have.attr', 'aria-sort') // Prison number
+    page.inReceptionHeaders().eq(5).should('not.have.attr', 'aria-sort') // Arrived from
+    page.inReceptionHeaders().eq(7).should('not.have.attr', 'aria-sort') // Alert flags
+  })
+
+  it('sorts Date of birth chronologically using the ISO date as the sort value', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    page.inReceptionRows().first().find('td').eq(3).should('have.attr', 'data-sort-value', '1980-01-01')
+  })
+
+  it('applies the govuk-!-font-size-16 override to the body cells', () => {
+    const page = Page.verifyOnPage(InReceptionPage)
+
+    page.inReceptionRows().first().find('td').eq(1).should('have.class', 'govuk-!-font-size-16')
+    page.inReceptionRows().first().find('td').eq(3).should('have.class', 'govuk-!-font-size-16')
+    page.inReceptionRows().first().find('td').eq(7).should('have.class', 'govuk-!-font-size-16')
+  })
 })

--- a/integration_tests/pages/inReception.ts
+++ b/integration_tests/pages/inReception.ts
@@ -6,4 +6,6 @@ export default class InReceptionPage extends Page {
   }
 
   inReceptionRows = (): PageElement => cy.get('table.in-reception-roll__table tbody tr')
+
+  inReceptionHeaders = (): PageElement => cy.get('table.in-reception-roll__table thead th')
 }

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -30,7 +30,7 @@
                         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Picture</span></th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="ascending">Name</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Prison number</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Date of birth</th>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Date of birth</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Arrived from</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
@@ -42,14 +42,14 @@
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}" ><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
-                            <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
-                            <td class="govuk-table__cell">{{ prisoner.timeArrived | formatTime }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.from }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisonerName }}" ><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.prisonerNumber }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisoner.dateOfBirth }}">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.timeArrived | formatTime }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
                             {% set csraLevel = prisoner.csra or 'None' %}
-                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}
 


### PR DESCRIPTION
## MAPB-131 — Amend the In reception page

[MAPB-131](https://dsdmoj.atlassian.net/browse/MAPB-131)

Brings the In reception table in line with the new design.

### Changes
- **Date of birth is now sortable** — adds `aria-sort` to the header and a `data-sort-value` of the raw ISO date (`1980-01-01`) on the cell, so it sorts chronologically rather than by the displayed `DD/MM/YYYY` text. Sortable columns are now Name, Date of birth, Time arrived and CSRA; Prison number / Arrived from / Alert flags are not.
- **Font** — applies the `govuk-!-font-size-16` override to the table body cells (the headers already had it), per the AC.
- **Row stroke** — SCSS so records are separated by a horizontal stroke, with no stroke on the last row's baseline (matches the Figma).

### Acceptance criteria status
| AC | Status |
|----|--------|
| All reception people displayed (prod parity) | Already in place (`getMovementsInReception`) — no change |
| Default sort Name (Surname, First) ascending | Already in place — no change |
| Sort by Name / Time arrived / CSRA | Already sortable (CSRA via MAPB-235) |
| Sort by Date of birth | ✅ Added in this PR |
| Horizontal stroke between records, none on last row | ✅ Added |
| Font override `govuk-!-font-size-16` | ✅ Added |
| "No relevant alerts" when none | ⛔ Out of scope — depends on **MAP-3063 (rejected)** |

### Out of scope
- The **"No relevant alerts"** empty state and the **"Relevant alerts"** column rename depend on **MAP-3063, which is rejected** — left out and flagged to product.
- Pagination, "Print this page" and the full-address "Arrived from" appear in the wider Figma but are not in this ticket's acceptance criteria.

### Testing
- `tsc` (app + integration_tests) and `eslint` pass.
- `jest` passes (22 tests).
- Cypress `inReception.cy.ts` passes (9 tests), with new assertions for DOB sortability, the ISO sort value, and the font override.
- Visually verified the rendered table: DOB sort arrow present, strokes between rows with none on the last row, body cells at font-size 16.

> Stacked on #177 (MAPB-201/MAPB-235), which it depends on for the CSRA column/sort. Base auto-retargets to `main` as the chain (MAPB-243 #176 → #177 → this) merges.

[MAPB-131]: https://dsdmoj.atlassian.net/browse/MAPB-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ