### PR TITLE
MAPB-225-er-add-return-breadcrumb-from-prisoner-profile-back-to-the-in-today-page

### DIFF
--- a/server/views/pages/arrivingToday.njk
+++ b/server/views/pages/arrivingToday.njk
@@ -42,7 +42,7 @@
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20Establishment%20roll&returnPath=/arrived-today&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
                             <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
                             <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
                             <td class="govuk-table__cell">{{ prisoner.cellLocation }}</td>

--- a/server/views/pages/arrivingToday.njk
+++ b/server/views/pages/arrivingToday.njk
@@ -42,7 +42,7 @@
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20Establishment%20roll&returnPath=/arrived-today&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Establishment%20roll&returnPath=/arrived-today&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
                             <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
                             <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
                             <td class="govuk-table__cell">{{ prisoner.cellLocation }}</td>


### PR DESCRIPTION
## Description

Updated link on prisoner profile name to include sending the relevant backlink information. This allows the profile service to include a "Establishment roll" link on the prisoner profile page.

Clicking that link (or using the back button) returns you to the "arrived-today" / "In today" page.

## Jira ticket

[MAPB-225](https://dsdmoj.atlassian.net/browse/MAPB-225)

## Screenshots

Screenshot is out of date, link now says "Establishment roll" but I don't have an example on dev to recreate it - all the establishments I can access don't have any "in today" prisoners.
<img width="538" height="381" alt="image" src="https://github.com/user-attachments/assets/6dd98e10-9508-4e0b-b7f8-2fc060397b64" />


[MAPB-225]: https://dsdmoj.atlassian.net/browse/MAPB-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ