### PR TITLE
MAPB-131-Estab-Roll-Amend-the-In-reception-page-alerts

### DIFF
--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -34,7 +34,7 @@
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Arrived from</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Alert flags</th>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Relevant alerts</th>
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
@@ -49,7 +49,7 @@
                             <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
                             {% set csraLevel = prisoner.csra or 'None' %}
                             <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20reception&returnPath=/in-reception&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}/csra-history" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) if prisoner.alertFlags | length else "No relevant alerts" }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}
 


### PR DESCRIPTION
## Description

Amended the "In reception" page to show "Relevant alerts" on the table header and the alertFlags will now show "No relevant alerts" if the array is empty.  This change will need to be replicated on other pages, so a generalised function to manage the alertFlags view would be preferred in the next change.


## Jira ticket

[MAPB-131](https://dsdmoj.atlassian.net/browse/MAPB-131)

## Screenshots

<img width="1208" height="447" alt="image" src="https://github.com/user-attachments/assets/b4eed0aa-021f-43ba-943b-33d05f0833b9" />


[MAPB-131]: https://dsdmoj.atlassian.net/browse/MAPB-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ