### PR TITLE
MAPB-225-er-add-return-breadcrumb-from-prisoner-profile-back-to-in-today-page

### DIFF
--- a/server/views/pages/arrivingToday.njk
+++ b/server/views/pages/arrivingToday.njk
@@ -42,7 +42,7 @@
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Establishment%20roll&returnPath=/arrived-today&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}"><a href="{{ config.serviceUrls.prisonerProfile }}/save-backlink?service=prison-roll-count&backLinkText=Back%20to%20In%20today&returnPath=/arrived-today&redirectPath=/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisonerName }}</a></td>
                             <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
                             <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
                             <td class="govuk-table__cell">{{ prisoner.cellLocation }}</td>


### PR DESCRIPTION
## Description

MAPB-225 Modified the text of the backlink to make it consistent with the "In reception" page which also has a similar backlink to prisoner profile

## Jira ticket

[MAPB-225](https://dsdmoj.atlassian.net/browse/MAPB-225)

## Screenshots

<img width="479" height="214" alt="image" src="https://github.com/user-attachments/assets/33c4ccc3-66a4-4056-8f67-8ae520842efa" />

[MAPB-225]: https://dsdmoj.atlassian.net/browse/MAPB-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ