### PR TITLE
MAPB-665-er-running-in-watch-mode-doesnt-restart-server-on-file-changes

### DIFF
--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -77,12 +77,12 @@ const main = () => {
     process.stderr.write('\u{1b}[1m\u{1F52D} Watching for changes...\u{1b}[0m\n')
     // Assets
     chokidar
-      .watch(['assets/**/*'], chokidarOptions)
+      .watch(['assets'], chokidarOptions)
       .on('all', () => buildAssets(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
 
     // App
     chokidar
-      .watch(['server/**/*'], { ...chokidarOptions, ignored: ['**/*.test.ts'] })
+      .watch(['server'], { ...chokidarOptions, ignored: ['**/*.test.ts'] })
       .on('all', () => buildApp(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
   }
 }


### PR DESCRIPTION
## Description

Modified chokidar watch commands and tested locally to ensure that file changes are correctly triggering the rebuild.

## Jira ticket

[MAPB-665](https://dsdmoj.atlassian.net/browse/MAPB-665)

## Screenshots

Ran server and modified a TS file - rebuild was triggered:

<img width="661" height="214" alt="image" src="https://github.com/user-attachments/assets/ba559e6a-1d50-4d90-beb7-57bc8847e456" />



[MAPB-665]: https://dsdmoj.atlassian.net/browse/MAPB-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ