### PR TITLE
MAPB-237: CSRA column added to In Today page

### DIFF
--- a/integration_tests/e2e/arrivedToday.cy.ts
+++ b/integration_tests/e2e/arrivedToday.cy.ts
@@ -37,23 +37,24 @@ context('Arrived Today Page', () => {
   it('should display alerts and category if cat A', () => {
     const page = Page.verifyOnPage(ArrivedTodayPage)
 
-    page.arrivedTodayRows().eq(1).find('td').eq(7).should('contain.text', 'Hidden disability')
-    page.arrivedTodayRows().eq(1).find('td').eq(7).should('contain.text', 'CAT A')
+    page.arrivedTodayRows().eq(1).find('td').eq(8).should('contain.text', 'Hidden disability')
+    page.arrivedTodayRows().eq(1).find('td').eq(8).should('contain.text', 'CAT A')
   })
 
-  it('makes Name, "Time arrived" and "Arrived from" sortable but not the other columns', () => {
+  it('makes Name, "Time arrived", "Arrived from" and "CSRA" sortable but not the other columns', () => {
     const page = Page.verifyOnPage(ArrivedTodayPage)
 
     // Sortable columns expose aria-sort
     page.arrivedTodayHeaders().eq(1).should('have.attr', 'aria-sort') // Name
     page.arrivedTodayHeaders().eq(5).should('have.attr', 'aria-sort') // Time arrived
     page.arrivedTodayHeaders().eq(6).should('have.attr', 'aria-sort') // Arrived from
+    page.arrivedTodayHeaders().eq(7).should('have.attr', 'aria-sort') // CSRA
 
     // Non-sortable columns do not
     page.arrivedTodayHeaders().eq(2).should('not.have.attr', 'aria-sort') // Prison number
     page.arrivedTodayHeaders().eq(3).should('not.have.attr', 'aria-sort') // Date of birth
     page.arrivedTodayHeaders().eq(4).should('not.have.attr', 'aria-sort') // Location
-    page.arrivedTodayHeaders().eq(7).should('not.have.attr', 'aria-sort') // Alert flags
+    page.arrivedTodayHeaders().eq(8).should('not.have.attr', 'aria-sort') // Alert flags
   })
 
   it('name link returns to the arrived-today page via the prisoner profile back link', () => {

--- a/server/views/pages/arrivingToday.njk
+++ b/server/views/pages/arrivingToday.njk
@@ -34,6 +34,7 @@
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Location</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="descending">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Arrived from</th>
+                      <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Alert flags</th>
                     </tr>
                 </thead>
@@ -49,6 +50,8 @@
                             <td class="govuk-table__cell">{{ prisoner.cellLocation }}</td>
                             <td class="govuk-table__cell">{{ prisoner.movementTime | formatTime}}</td>
                             <td class="govuk-table__cell">{{ prisoner.arrivedFrom }}</td>
+                            {% set csraLevel = prisoner.csra or 'None' %}
+                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to In today', '/arrived-today', prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
                             <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}

--- a/server/views/pages/arrivingToday.njk
+++ b/server/views/pages/arrivingToday.njk
@@ -34,7 +34,7 @@
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Location</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="descending">Time arrived</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Arrived from</th>
-                      <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
+                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
                         <th scope="col" class="govuk-table__header govuk-!-font-size-16">Alert flags</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
## Description

CSRA column added to In Today page so a prisoner's level can be viewed if they have one. If they have no CSRA level 'None' should be displayed instead.

## Jira ticket

[MAPB-237](https://dsdmoj.atlassian.net/browse/MAPB-237)



[MAPB-237]: https://dsdmoj.atlassian.net/browse/MAPB-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ