### PR TITLE
MAPB-199: Add pagination to the Establishment Roll 'In Reception' page

### DIFF
--- a/assets/scss/components/_results-table.scss
+++ b/assets/scss/components/_results-table.scss
@@ -1,6 +1,10 @@
 // Results table container
 .results-table__results {
   overflow: auto;
+
+  .govuk-pagination {
+    margin-bottom: 10px; // override of govuk component for our layout
+  }
 }
 
 // Image column sizing

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -117,7 +117,7 @@ export default class EstablishmentRollController {
         currentPage,
         totalPages,
         totalResults,
-        pageSize
+        pageSize,
       })
     }
   }

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -5,6 +5,17 @@ import LocationService from '../services/locationsService'
 import { userHasRoles } from '../utils/utils'
 import Role from '../enums/role'
 
+const pageSize = 5
+
+const getCurrentPage = (query: Request['query'], totalPages: number) => {
+  const requestedPage =
+    typeof query?.page === 'string' && Number.parseInt(query.page, 10) > 0 ? Number.parseInt(query.page, 10) : 1
+
+  if (totalPages === 0) return 1
+
+  return Math.min(requestedPage, totalPages)
+}
+
 export default class EstablishmentRollController {
   constructor(
     private readonly establishmentRollService: EstablishmentRollService,
@@ -93,7 +104,21 @@ export default class EstablishmentRollController {
       const { clientToken } = req.middleware
 
       const prisonersEnRoute = await this.movementsService.getInReceptionPrisoners(clientToken, user.activeCaseLoadId)
-      res.render('pages/inReception', { prisoners: prisonersEnRoute, prison: user.activeCaseLoad.description })
+
+      const totalResults = prisonersEnRoute.length
+      const totalPages = Math.ceil(prisonersEnRoute.length / pageSize)
+      const currentPage = getCurrentPage(req.query, totalPages)
+      const startIndex = (currentPage - 1) * pageSize
+      const prisonersForCurrentPage = prisonersEnRoute.slice(startIndex, startIndex + pageSize)
+
+      res.render('pages/inReception', {
+        prisoners: prisonersForCurrentPage,
+        prison: user.activeCaseLoad.description,
+        currentPage,
+        totalPages,
+        totalResults,
+        pageSize
+      })
     }
   }
 

--- a/server/views/macros/pagination.njk
+++ b/server/views/macros/pagination.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
+{#
+Renders a govukPagination component with numbered page items and prev/next links,
+along with result count summary.
+
+Params:
+  currentPage {number} - The current 1-based page number
+  totalPages  {number} - The total number of pages
+  baseHref    {string} - The URL to link to, without a page parameter (page=N will be appended)
+  totalResults {number} - Optional: Total number of results (displays "Showing x to y of z")
+  pageSize    {number} - Optional: Number of results per page (default: 25)
+#}
+{% macro pagination(currentPage, totalPages, baseHref, totalResults, pageSize) %}
+  {% set pageSize = pageSize or 25 %}
+  {% set pageParamPrefix = '&' if '?' in baseHref else '?' %}
+  {% set startItem = (currentPage - 1) * pageSize + 1 %}
+  {% set endItem = currentPage * pageSize %}
+  {% if endItem > totalResults %}{% set endItem = totalResults %}{% endif %}
+
+  <div class="pagination">
+    {% if totalPages > 1 %}
+      {% set windowStart = currentPage - 1 %}
+      {% if windowStart < 1 %}{% set windowStart = 1 %}{% endif %}
+      {% set windowEnd = currentPage + 1 %}
+      {% if windowEnd > totalPages %}{% set windowEnd = totalPages %}{% endif %}
+
+      {% set paginationItems = [] %}
+
+      {% if windowStart > 1 %}
+        {% set _ = paginationItems.push({ number: 1, href: baseHref ~ pageParamPrefix ~ "page=1", current: currentPage == 1 }) %}
+        {% if windowStart > 2 %}
+          {% set _ = paginationItems.push({ ellipsis: true }) %}
+        {% endif %}
+      {% endif %}
+
+      {% for i in range(windowStart, windowEnd + 1) %}
+        {% set _ = paginationItems.push({ number: i, href: baseHref ~ pageParamPrefix ~ "page=" ~ i, current: i == currentPage }) %}
+      {% endfor %}
+
+      {% if windowEnd < totalPages %}
+        {% if windowEnd < totalPages - 1 %}
+          {% set _ = paginationItems.push({ ellipsis: true }) %}
+        {% endif %}
+        {% set _ = paginationItems.push({ number: totalPages, href: baseHref ~ pageParamPrefix ~ "page=" ~ totalPages, current: currentPage == totalPages }) %}
+      {% endif %}
+
+      {{ govukPagination({
+        previous: { href: baseHref ~ pageParamPrefix ~ "page=" ~ (currentPage - 1) } if currentPage > 1,
+        next: { href: baseHref ~ pageParamPrefix ~ "page=" ~ (currentPage + 1) } if currentPage < totalPages,
+        items: paginationItems
+      }) }}
+
+      {% if totalResults %}
+        <p class="govuk-body pagination-results-summary govuk-!-margin-bottom-6">
+          Showing {{ startItem }} to {{ endItem }} of {{ totalResults }} total results
+        </p>
+      {% endif %}
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "../macros/alertFlags.njk" import alertFlags %}
 {% from "../macros/categoryFlag.njk" import categoryFlag %}
+{% from "../macros/pagination.njk" import pagination %}
 
 {% set pageTitle = "In reception"%}
 {% set mainClasses = "govuk-body govuk-main-wrapper--auto-spacing" %}
@@ -17,13 +18,16 @@
 ] %}
 
 {% block content %}
-<div class="govuk-width-container govuk-!-margin-top-8">
-    <div class="govuk-!-margin-bottom-6">
+  <div class="govuk-width-container govuk-!-margin-top-4">
+    <div class="govuk-!-margin-bottom-9">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ pageTitle }}</h1>
     </div>
 
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
-        <div class="govuk-grid-column-full results-table results-table__results">
+        <div class="govuk-grid-column-full results-table results-table__results govuk-!-margin-top-2">
+          {% set paginationBase = '/in-reception' %}
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
+
             <table class="govuk-table in-reception-roll__table" data-module="moj-sortable-table">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
@@ -60,6 +64,8 @@
                 {% endif %}
                 </tbody>
             </table>
+
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

Pagination added to the In Reception page in Establishment Roll so that prisoner details can be viewed in smaller chunks and page-load speeds can be improved when there are big data sets. Pagination should appear above and below the table of results. As there are only 16 results in dev right now I have set the page size to 5 for testing purposes (normally default page size is 25 so this can be reset following testing)

## Jira ticket

[MAPB-199](https://dsdmoj.atlassian.net/browse/MAPB-199)

## Screenshots

<img width="843" height="832" alt="image" src="https://github.com/user-attachments/assets/52f43633-c13d-48f4-a07f-63cc5d5a2948" />


[MAPB-199]: https://dsdmoj.atlassian.net/browse/MAPB-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ