### PR TITLE
MAPB-775 Updated hmpps-connect-dps-shared-items package to the latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - LOCATIONS_INSIDE_PRISON_API_CLIENT_SECRET=clientsecret
 
   localstack:
-    image: localstack/localstack:stable
+    image: localstack/localstack:community-archive
     networks:
       - hmpps
     container_name: localstack

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-sqs": "3.1052.0",
         "@ministryofjustice/frontend": "^10.0.1",
         "@ministryofjustice/hmpps-connect-dps-components": "6.1.0",
-        "@ministryofjustice/hmpps-connect-dps-shared-items": "4.1.1",
+        "@ministryofjustice/hmpps-connect-dps-shared-items": "4.4.0",
         "@ministryofjustice/hmpps-monitoring": "^2.1.0",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^3.15.0",
@@ -3422,15 +3422,28 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-shared-items": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-shared-items/-/hmpps-connect-dps-shared-items-4.1.1.tgz",
-      "integrity": "sha512-+T77yt+vKEV26sbr+1hosDVup7MWB4kErkvKeYRaepP76g6e2rHnC47YC/2XBmVNCeDzuhEEaNJEWACSVSE0zQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-shared-items/-/hmpps-connect-dps-shared-items-4.4.0.tgz",
+      "integrity": "sha512-CIDlOGlaoCddPRdsLZJVu21xFfR0kXHi48JUKw8QF1X+JfsW/jHjRYVLfpR/ulrPIfIWzsFA3J22ADmS4f7tkg==",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/hmpps-rest-client": "2.1.0",
+        "@ministryofjustice/hmpps-rest-client": "2.2.0",
         "@types/bunyan": "^1.8.11",
-        "fuse.js": "7.4.1",
+        "fuse.js": "7.5.0",
         "superagent": "10.3.0"
+      },
+      "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-connect-dps-shared-items/node_modules/@ministryofjustice/hmpps-rest-client": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.2.0.tgz",
+      "integrity": "sha512-sZQ6K47NvtcE4trUGRS85JqVRpBHAteuC8XT0N5qB14TLniNJVvRVoCK6O/gGwT9wQEzLW7C6DW1T6SOFGnTrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agentkeepalive": "^4.6.0",
+        "superagent": "^10.3.0"
       },
       "engines": {
         "node": "22 || 24 || 26"
@@ -10639,9 +10652,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.1.tgz",
-      "integrity": "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@aws-sdk/client-sqs": "3.1052.0",
     "@ministryofjustice/frontend": "^10.0.1",
     "@ministryofjustice/hmpps-connect-dps-components": "6.1.0",
-    "@ministryofjustice/hmpps-connect-dps-shared-items": "4.1.1",
+    "@ministryofjustice/hmpps-connect-dps-shared-items": "4.4.0",
     "@ministryofjustice/hmpps-monitoring": "^2.1.0",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^3.15.0",


### PR DESCRIPTION
Updated hmpps-connect-dps-shared-items package to the latest version (had to temporarily set the min-release-age to 0 for the update command to work, the package is only 2 days old at this point).  Tested and ran unit and UI tests.

Also updated localstack to use the community-archive version for local dev.

## Description

AlertFlags now includes 'Security - Not For Release' and 'Security - High Public Interest' and it is important to ensure these changes are propogated through our various apps.

## Jira ticket

[MAPB-775](https://dsdmoj.atlassian.net/browse/MAPB-775)

## Screenshots

n/a


[MAPB-775]: https://dsdmoj.atlassian.net/browse/MAPB-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ