### PR TITLE
MAPB-239: Add pagination to the Establishment Roll 'Incoming transfers' page

### DIFF
--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -107,7 +107,20 @@ export default class EstablishmentRollController {
 
       const prisonersEnRoute = await this.movementsService.getEnRoutePrisoners(clientToken, user.activeCaseLoadId)
 
-      res.render('pages/enRoute', { prisoners: prisonersEnRoute, prison: user.activeCaseLoad.description })
+      const totalResults = prisonersEnRoute.length
+      const totalPages = Math.ceil(prisonersEnRoute.length / pageSize)
+      const currentPage = getCurrentPage(req.query, totalPages)
+      const startIndex = (currentPage - 1) * pageSize
+      const prisonersForCurrentPage = prisonersEnRoute.slice(startIndex, startIndex + pageSize)
+
+      res.render('pages/enRoute', {
+        prisoners: prisonersForCurrentPage,
+        prison: user.activeCaseLoad.description,
+        currentPage,
+        pageSize,
+        totalPages,
+        totalResults,
+      })
     }
   }
 

--- a/server/views/pages/enRoute.njk
+++ b/server/views/pages/enRoute.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "../macros/alertFlags.njk" import alertFlags %}
 {% from "../macros/categoryFlag.njk" import categoryFlag %}
+{% from "../macros/pagination.njk" import pagination %}
 
 {% set pageTitle = "Incoming transfers" %}
 {% set mainClasses = "govuk-body govuk-main-wrapper--auto-spacing" %}
@@ -17,14 +18,18 @@
 ] %}
 
 {% block content %}
-<div class="govuk-width-container govuk-!-margin-top-8">
-    <div class="govuk-!-margin-bottom-6">
+  <div class="govuk-width-container govuk-!-margin-top-4">
+    <div class="govuk-!-margin-bottom-9">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ pageTitle }}</h1>
     </div>
 
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
         <div class="govuk-grid-column-full results-table results-table__results">
-            <table class="govuk-table en-route-roll__table" data-module="moj-sortable-table">
+          {% set paginationBase = 'en-route' %}
+
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
+
+          <table class="govuk-table en-route-roll__table" data-module="moj-sortable-table">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Picture</span></th>
@@ -43,16 +48,16 @@
                     {% for prisoner in prisoners %}
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
-                            <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}" ><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber) }}" class="govuk-link">{{ prisonerName }}</a></td>
-                            <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
-                            <td class="govuk-table__cell" data-sort-value="{{ prisoner.movementDate | toUnixTimeStamp(prisoner.movementTime) }}" >{{ prisoner.movementTime | formatTime }}<br />{{ prisoner.movementDate | formatDate('short')}}</td>
-                            <td class="govuk-table__cell">{{ prisoner.from }}</td>
-                            <td class="govuk-table__cell">{{ prisoner.reason }}</td>
+                            <td class="govuk-table__cell  govuk-!-font-size-16"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisonerName }}" ><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber) }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.prisonerNumber }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisoner.movementDate | toUnixTimeStamp(prisoner.movementTime) }}" >{{ prisoner.movementTime | formatTime }}<br />{{ prisoner.movementDate | formatDate('short')}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.reason }}</td>
                             {% set csraLevel = prisoner.csra or 'None' %}
-                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
+                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
+                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}
                 {% else %}
@@ -61,7 +66,9 @@
                   </tr>
                 {% endif %}
                 </tbody>
-            </table>
+          </table>
+
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
         </div>
     </div>
 </div>

--- a/server/views/pages/enRoute.njk
+++ b/server/views/pages/enRoute.njk
@@ -29,18 +29,18 @@
 
           {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
 
-          <table class="govuk-table en-route-roll__table" data-module="moj-sortable-table">
+          <table class="govuk-table en-route-roll__table govuk-!-font-size-16" data-module="moj-sortable-table">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Picture</span></th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="ascending">Name</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Prison number</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Date of birth</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Departed</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">En route from</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Reason</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Alert flags</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="ascending">Name</th>
+                        <th scope="col" class="govuk-table__header">Prison number</th>
+                        <th scope="col" class="govuk-table__header">Date of birth</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="none">Departed</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="none">En route from</th>
+                        <th scope="col" class="govuk-table__header">Reason</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="none">CSRA</th>
+                        <th scope="col" class="govuk-table__header">Alert flags</th>
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
@@ -48,16 +48,16 @@
                     {% for prisoner in prisoners %}
                         {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
                         <tr class="govuk-table__row">
-                            <td class="govuk-table__cell  govuk-!-font-size-16"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisonerName }}" ><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber) }}" class="govuk-link">{{ prisonerName }}</a></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.prisonerNumber }}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisoner.movementDate | toUnixTimeStamp(prisoner.movementTime) }}" >{{ prisoner.movementTime | formatTime }}<br />{{ prisoner.movementDate | formatDate('short')}}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.reason }}</td>
+                            <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
+                            <td class="govuk-table__cell" data-sort-value="{{ prisonerName }}" ><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber) }}" class="govuk-link">{{ prisonerName }}</a></td>
+                            <td class="govuk-table__cell">{{ prisoner.prisonerNumber }}</td>
+                            <td class="govuk-table__cell">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
+                            <td class="govuk-table__cell" data-sort-value="{{ prisoner.movementDate | toUnixTimeStamp(prisoner.movementTime) }}" >{{ prisoner.movementTime | formatTime }}<br />{{ prisoner.movementDate | formatDate('short')}}</td>
+                            <td class="govuk-table__cell">{{ prisoner.from }}</td>
+                            <td class="govuk-table__cell">{{ prisoner.reason }}</td>
                             {% set csraLevel = prisoner.csra or 'None' %}
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
+                            <td class="govuk-table__cell" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to Incoming transfers', '/en-route', prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
+                            <td class="govuk-table__cell">{{ alertFlags(prisoner.alertFlags) }}{{categoryFlag("", prisoner.category) | safe}}</td>
                         </tr>
                     {% endfor %}
                 {% else %}


### PR DESCRIPTION
## Description

- Pagination added to the Incoming Transfers page in Establishment Roll so that prisoner details can be viewed in smaller chunks and page-load speeds can be improved when there are big data sets. 
- Pagination should appear above and below the table of results. 
- As there are only 9 results in dev right now I have set the page size to 5 for testing purposes (normally default page size is 25 so this can be reset following testing)
- Styling also updated on this page as the table wasn't using the size 16 font consistently

## Jira ticket

[MAPB-239](https://dsdmoj.atlassian.net/browse/MAPB-239)

## Screenshots

<img width="639" height="558" alt="image" src="https://github.com/user-attachments/assets/0148a760-a579-49f2-ab7f-64d7eca21db6" />


[MAPB-239]: https://dsdmoj.atlassian.net/browse/MAPB-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ