### PR TITLE
ER page size reverted to 25, PAGE_SIZE added as env variable

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -147,4 +147,5 @@ export default {
   featureFlags: {
     eRollRebuild: get('FLAG_E_ROLL_REBUILD', 'disabled') === 'enabled',
   },
+  envPageSize: Number(get('PAGE_SIZE', 25)),
 }

--- a/server/controllers/establishmentRollController.test.ts
+++ b/server/controllers/establishmentRollController.test.ts
@@ -323,7 +323,7 @@ describe('EstablishmentRollController', () => {
       )
       expect(res.render).toHaveBeenCalledWith('pages/overnights', {
         currentPage: 1,
-        pageSize: 5,
+        pageSize: 25,
         prisoners: [],
         prison: 'Leeds',
         totalPages: 0,
@@ -353,7 +353,7 @@ describe('EstablishmentRollController', () => {
       expect(movementsService.getOvernightPrisoners).toHaveBeenCalledWith('token', 'LEI', 'reason&direction=ascending')
       expect(res.render).toHaveBeenCalledWith('pages/overnights', {
         currentPage: 1,
-        pageSize: 5,
+        pageSize: 25,
         prisoners: [],
         prison: 'Leeds',
         sort: 'reason&direction=ascending',
@@ -383,11 +383,11 @@ describe('EstablishmentRollController', () => {
 
       expect(res.render).toHaveBeenCalledWith('pages/overnights', {
         currentPage: 2,
-        pageSize: 5,
-        prisoners: prisoners.slice(5, 10),
+        pageSize: 25,
+        prisoners: prisoners.slice(25, 50),
         prison: 'Leeds',
         sort: 'timeDateDeparted&direction=descending',
-        totalPages: 6,
+        totalPages: 2,
         totalResults: 30,
       })
     })

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -4,6 +4,7 @@ import MovementsService from '../services/movementsService'
 import LocationService from '../services/locationsService'
 import { userHasRoles } from '../utils/utils'
 import Role from '../enums/role'
+import config from '../config'
 
 const getSortParam = (
   query: Request['query'],
@@ -16,7 +17,7 @@ const getSortParam = (
   return `${sortKey}&direction=${direction}`
 }
 
-const pageSize = Number(process.env.PAGE_SIZE) || 25
+const pageSize = Number(config.envPageSize) || 25
 
 const getCurrentPage = (query: Request['query'], totalPages: number) => {
   const requestedPage =

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -16,7 +16,7 @@ const getSortParam = (
   return `${sortKey}&direction=${direction}`
 }
 
-const pageSize = 5
+const pageSize = Number(process.env.PAGE_SIZE) || 25
 
 const getCurrentPage = (query: Request['query'], totalPages: number) => {
   const requestedPage =

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -17,7 +17,7 @@ const getSortParam = (
   return `${sortKey}&direction=${direction}`
 }
 
-const pageSize = Number(config.envPageSize) || 25
+const pageSize = config.envPageSize
 
 const getCurrentPage = (query: Request['query'], totalPages: number) => {
   const requestedPage =

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -54,6 +54,9 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('prisonerProfileUrl', prisonerProfileUrl)
   njkEnv.addGlobal('prisonerProfileBackLinkUrl', prisonerProfileBackLinkUrl)
 
+  // Expose the page size override to the nunjucks environment
+  njkEnv.addGlobal('envPageSize', config.envPageSize)
+
   // Expose the google tag manager container ID to the nunjucks environment
   const {
     analytics: { tagManagerContainerId },

--- a/server/views/macros/pagination.njk
+++ b/server/views/macros/pagination.njk
@@ -11,7 +11,7 @@ Params:
   totalResults {number} - Optional: Total number of results (displays "Showing x to y of z")
   pageSize    {number} - Optional: Number of results per page (default: 25)
 #}
-{% macro pagination(currentPage, totalPages, baseHref, totalResults, envPageSize) %}
+{% macro pagination(currentPage, totalPages, baseHref, totalResults, pageSize) %}
   {% set pageSize = pageSize or 25 %}
   {% set pageParamPrefix = '&' if '?' in baseHref else '?' %}
   {% set startItem = (currentPage - 1) * pageSize + 1 %}

--- a/server/views/macros/pagination.njk
+++ b/server/views/macros/pagination.njk
@@ -11,7 +11,7 @@ Params:
   totalResults {number} - Optional: Total number of results (displays "Showing x to y of z")
   pageSize    {number} - Optional: Number of results per page (default: 25)
 #}
-{% macro pagination(currentPage, totalPages, baseHref, totalResults, pageSize) %}
+{% macro pagination(currentPage, totalPages, baseHref, totalResults, envPageSize) %}
   {% set pageSize = pageSize or 25 %}
   {% set pageParamPrefix = '&' if '?' in baseHref else '?' %}
   {% set startItem = (currentPage - 1) * pageSize + 1 %}

--- a/server/views/pages/enRoute.njk
+++ b/server/views/pages/enRoute.njk
@@ -29,7 +29,7 @@
           {% set pageParam = '?page=' ~ currentPage if currentPage > 1 else '' %}
           {% set returnPathWithPage = '/en-route' ~ pageParam %}
 
-          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, envPageSize) }}
 
           <table class="govuk-table en-route-roll__table govuk-!-font-size-16" data-module="moj-sortable-table">
                 <thead class="govuk-table__head">

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -28,7 +28,7 @@
           {% set paginationBase = '/in-reception' %}
           {% set pageParam = '?page=' ~ currentPage if currentPage > 1 else '' %}
           {% set returnPathWithPage = '/in-reception' ~ pageParam %}
-          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, envPageSize) }}
 
             <table class="govuk-table in-reception-roll__table" data-module="moj-sortable-table">
                 <thead class="govuk-table__head">


### PR DESCRIPTION
## Description

The pageSize value was hard-coded at 5 for testing the pagination on the ER dev environment so this restores the pageSize to 25 which was the original default. It also adds an .env variable PAGE_SIZE which will override the 25 when set so we can keep a smaller page size in testing.  
