### PR TITLE
MAPB-204: Add default and custom sort for In Reception page

### DIFF
--- a/integration_tests/e2e/inReception.cy.ts
+++ b/integration_tests/e2e/inReception.cy.ts
@@ -27,7 +27,7 @@ context('In reception Page', () => {
 
     page.inReceptionRows().first().find('td').eq(1).should('contain.text', 'Shannon, Eddie')
     page.inReceptionRows().first().find('td').eq(2).should('contain.text', 'A1234AB')
-    page.inReceptionRows().first().find('td').eq(3).should('contain.text', '01/01/1980')
+    page.inReceptionRows().first().find('td').eq(3).should('contain.text', '1 Jan 1980')
     page.inReceptionRows().first().find('td').eq(4).should('contain.text', '11:00')
     page.inReceptionRows().first().find('td').eq(5).should('contain.text', 'Leeds')
     // Column index 6 checked in the CSRA level test
@@ -102,17 +102,9 @@ context('In reception Page', () => {
     page.inReceptionRows().first().find('td').eq(3).should('have.attr', 'data-sort-value', '1980-01-01')
   })
 
-  it('applies the govuk-!-font-size-16 override to the body cells', () => {
-    const page = Page.verifyOnPage(InReceptionPage)
-
-    page.inReceptionRows().first().find('td').eq(1).should('have.class', 'govuk-!-font-size-16')
-    page.inReceptionRows().first().find('td').eq(3).should('have.class', 'govuk-!-font-size-16')
-    page.inReceptionRows().first().find('td').eq(7).should('have.class', 'govuk-!-font-size-16')
-  })
-
   it('name link returns to the in-reception page via the prisoner profile back link', () => {
     const page = Page.verifyOnPage(InReceptionPage)
-
+    const returnPath = encodeURIComponent('/in-reception?sort=prisonerName&direction=ascending')
     page
       .inReceptionRows()
       .first()
@@ -122,8 +114,8 @@ context('In reception Page', () => {
       .should('have.attr', 'href')
       .and('contain', '/save-backlink')
       .and('contain', 'service=prison-roll-count')
-      .and('contain', 'backLinkText=Back%20to%20In%20reception')
-      .and('contain', 'returnPath=/in-reception')
+      .and('contain', 'backLinkText=Back%20to%20In%20Reception')
+      .and('contain', `returnPath=${returnPath}`)
       .and('contain', 'redirectPath=/prisoner/A1234AB')
   })
 })

--- a/integration_tests/e2e/inReception.cy.ts
+++ b/integration_tests/e2e/inReception.cy.ts
@@ -51,7 +51,7 @@ context('In reception Page', () => {
 
   it('name link returns to the In reception page via the prisoner profile back link', () => {
     const page = Page.verifyOnPage(InReceptionPage)
-
+    const returnPath = encodeURIComponent('/in-reception?sort=prisonerName&direction=ascending')
     page
       .inReceptionRows()
       .first()
@@ -61,13 +61,13 @@ context('In reception Page', () => {
       .should('have.attr', 'href')
       .and('contain', '/save-backlink')
       .and('contain', 'service=prison-roll-count')
-      .and('contain', 'returnPath=/in-reception')
+      .and('contain', `returnPath=${returnPath}`)
       .and('contain', 'redirectPath=/prisoner/A1234AB')
   })
 
   it('CSRA link goes to the CSRA history page and returns to the In reception page via the back link', () => {
     const page = Page.verifyOnPage(InReceptionPage)
-
+    const returnPath = encodeURIComponent('/in-reception?sort=prisonerName&direction=ascending')
     page
       .inReceptionRows()
       .first()
@@ -77,7 +77,7 @@ context('In reception Page', () => {
       .should('have.attr', 'href')
       .and('contain', '/save-backlink')
       .and('contain', 'service=prison-roll-count')
-      .and('contain', 'returnPath=/in-reception')
+      .and('contain', `returnPath=${returnPath}`)
       .and('contain', 'redirectPath=/prisoner/A1234AB/csra-history')
   })
 

--- a/server/controllers/establishmentRollController.test.ts
+++ b/server/controllers/establishmentRollController.test.ts
@@ -11,6 +11,7 @@ const establishmentRollService = {
 const movementsService = {
   getOffendersCurrentlyOutOfBed: jest.fn(),
   getOffendersCurrentlyOutOfLivingUnit: jest.fn(),
+  getInReceptionPrisoners: jest.fn(),
   getOvernightPrisoners: jest.fn(),
 }
 const locationService = {
@@ -389,6 +390,73 @@ describe('EstablishmentRollController', () => {
         sort: 'timeDateDeparted&direction=descending',
         totalPages: 2,
         totalResults: 30,
+      })
+    })
+  })
+
+  describe('getInReception', () => {
+    it('defaults sort to prisonerName&direction=ascending when no query is provided', async () => {
+      movementsService.getInReceptionPrisoners.mockResolvedValue([])
+
+      const controller = new EstablishmentRollController(
+        establishmentRollService as unknown as EstablishmentRollService,
+        movementsService as unknown as MovementsService,
+        locationService as unknown as LocationService,
+      )
+
+      const req = mockReq()
+      const res = mockRes()
+      const next = mockNext()
+
+      await controller.getInReception()(req, res, next)
+
+      expect(movementsService.getInReceptionPrisoners).toHaveBeenCalledWith(
+        'token',
+        'LEI',
+        'prisonerName&direction=ascending',
+      )
+      expect(res.render).toHaveBeenCalledWith('pages/inReception', {
+        currentPage: 1,
+        pageSize: 25,
+        prisoners: [],
+        prison: 'Leeds',
+        sort: 'prisonerName&direction=ascending',
+        totalPages: 0,
+        totalResults: 0,
+      })
+    })
+
+    it('combines sort and direction query params when provided', async () => {
+      movementsService.getInReceptionPrisoners.mockResolvedValue([])
+
+      const controller = new EstablishmentRollController(
+        establishmentRollService as unknown as EstablishmentRollService,
+        movementsService as unknown as MovementsService,
+        locationService as unknown as LocationService,
+      )
+
+      const req = {
+        ...mockReq(),
+        query: { sort: 'timeArrived', direction: 'descending' },
+      } as unknown as Request
+      const res = mockRes()
+      const next = mockNext()
+
+      await controller.getInReception()(req, res, next)
+
+      expect(movementsService.getInReceptionPrisoners).toHaveBeenCalledWith(
+        'token',
+        'LEI',
+        'timeArrived&direction=descending',
+      )
+      expect(res.render).toHaveBeenCalledWith('pages/inReception', {
+        currentPage: 1,
+        pageSize: 25,
+        prisoners: [],
+        prison: 'Leeds',
+        sort: 'timeArrived&direction=descending',
+        totalPages: 0,
+        totalResults: 0,
       })
     })
   })

--- a/server/controllers/establishmentRollController.ts
+++ b/server/controllers/establishmentRollController.ts
@@ -129,8 +129,13 @@ export default class EstablishmentRollController {
     return async (req: Request, res: Response) => {
       const { user } = res.locals
       const { clientToken } = req.middleware
+      const sort = getSortParam(req.query, 'prisonerName', 'ascending')
 
-      const prisonersEnRoute = await this.movementsService.getInReceptionPrisoners(clientToken, user.activeCaseLoadId)
+      const prisonersEnRoute = await this.movementsService.getInReceptionPrisoners(
+        clientToken,
+        user.activeCaseLoadId,
+        sort,
+      )
 
       const totalResults = prisonersEnRoute.length
       const totalPages = Math.ceil(prisonersEnRoute.length / pageSize)
@@ -141,6 +146,7 @@ export default class EstablishmentRollController {
       res.render('pages/inReception', {
         prisoners: prisonersForCurrentPage,
         prison: user.activeCaseLoad.description,
+        sort,
         currentPage,
         totalPages,
         totalResults,

--- a/server/services/movementsService.test.ts
+++ b/server/services/movementsService.test.ts
@@ -169,27 +169,28 @@ describe('movementsService', () => {
         expect.arrayContaining(['A1234AA', 'A1234AB']),
       )
 
-      expect(result).toEqual([
+      expect(result.map(prisoner => prisoner.prisonerNumber)).toEqual(['A1234AB', 'A1234AA'])
+      expect(result.map(prisoner => prisoner.from)).toEqual(['Leeds', 'Leicester'])
+      expect(result.map(prisoner => prisoner.timeArrived)).toEqual(['11:00', '10:00'])
+      expect(result[0].alertFlags).toEqual([])
+      expect(result[1].alertFlags).toEqual([
         {
-          ...prisonerSearchMock[0],
-          from: 'Leeds',
-          timeArrived: '11:00',
-          alertFlags: [],
-        },
-        {
-          ...prisonerSearchMock[1],
-          alertFlags: [
-            {
-              alertCodes: ['HID'],
-              alertIds: ['HID'],
-              classes: 'dps-alert-status dps-alert-status--medical',
-              label: 'Hidden disability',
-            },
-          ],
-          from: 'Leicester',
-          timeArrived: '10:00',
+          alertCodes: ['HID'],
+          alertIds: ['HID'],
+          classes: 'dps-alert-status dps-alert-status--medical',
+          label: 'Hidden disability',
         },
       ])
+    })
+
+    it('should default to sorting by prisonerName ascending', async () => {
+      prisonApiClientMock.getMovementsInReception = jest.fn().mockResolvedValue(movementsInReceptionMock)
+      prisonerSearchApiClientMock.getPrisonersById = jest.fn().mockResolvedValue(prisonerSearchMock)
+      prisonApiClientMock.getRecentMovements = jest.fn().mockResolvedValue(movementsRecentMock)
+
+      const result = await movementsService.getInReceptionPrisoners('token', 'LEI')
+
+      expect(result.map(prisoner => prisoner.prisonerNumber)).toEqual(['A1234AB', 'A1234AA'])
     })
 
     it('should return empty api if no incoming prisoners', async () => {

--- a/server/services/movementsService.ts
+++ b/server/services/movementsService.ts
@@ -163,6 +163,7 @@ export default class MovementsService {
   public async getInReceptionPrisoners(
     clientToken: string,
     caseLoadId: string,
+    sort: string = 'prisonerName&direction=ascending',
   ): Promise<(PrisonerWithAlerts & { from: string; timeArrived: string })[]> {
     const prisonApi = this.prisonApiClientBuilder(clientToken)
     const prisonerSearchClient = this.prisonerSearchClientBuilder(clientToken)
@@ -176,18 +177,48 @@ export default class MovementsService {
       prisonApi.getRecentMovements(prisonerNumbers),
     ])
 
-    return prisoners
-      .sort((a, b) => a.lastName.localeCompare(b.lastName, 'en', { ignorePunctuation: true }))
-      .map(prisoner => {
-        const recentMovement = recentMovements.find(movement => movement.offenderNo === prisoner.prisonerNumber)
+    const mappedPrisoners = prisoners.map((prisoner: PrisonerWithAlerts) => {
+      const recentMovement = recentMovements.find(movement => movement.offenderNo === prisoner.prisonerNumber)
 
-        return {
-          ...prisoner,
-          alertFlags: dpsShared.getAlertFlagLabelsForAlerts(prisoner.alerts),
-          from: recentMovement?.fromAgencyDescription,
-          timeArrived: recentMovement?.movementTime,
+      return {
+        ...prisoner,
+        alertFlags: dpsShared.getAlertFlagLabelsForAlerts(prisoner.alerts),
+        from: recentMovement?.fromAgencyDescription,
+        timeArrived: recentMovement?.movementTime,
+      }
+    })
+
+    const [sortKey = 'prisonerName', sortDirection = 'ascending'] = sort.split('&direction=')
+    const isAscending = sortDirection === 'ascending'
+    const compareStrings = (left: string, right: string) => left.localeCompare(right, 'en', { ignorePunctuation: true })
+
+    const sortedPrisoners = mappedPrisoners.sort((left, right) => {
+      let comparison = 0
+
+      switch (sortKey) {
+        case 'timeArrived':
+          comparison = compareStrings(left.timeArrived || '', right.timeArrived || '')
+          break
+        case 'dateOfBirth':
+          comparison = compareStrings(left.dateOfBirth || '', right.dateOfBirth || '')
+          break
+        case 'csra':
+          comparison = compareStrings(left.csra || 'None', right.csra || 'None')
+          break
+        case 'prisonerName':
+        default: {
+          comparison = compareStrings(left.lastName || '', right.lastName || '')
+          if (comparison === 0) {
+            comparison = compareStrings(left.firstName || '', right.firstName || '')
+          }
+          break
         }
-      })
+      }
+
+      return isAscending ? comparison : -comparison
+    })
+
+    return sortedPrisoners
   }
 
   public async getNoCellAllocatedPrisoners(

--- a/server/views/pages/establishmentRoll.njk
+++ b/server/views/pages/establishmentRoll.njk
@@ -93,7 +93,7 @@
             establishmentRollStatCard(
                 heading = "In reception",
                 value = todayStats.unassignedIn,
-                href = "/in-reception",
+                href = "/in-reception?sort=prisonerName&direction=ascending",
                 qaTag = "unassigned-in-card"
             )
         }}

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -47,7 +47,7 @@
                 html: '<img src="/prisonerImage/' ~ (prisoner.prisonerNumber or 'placeholder') ~ '" alt="Image of ' ~ prisonerName ~ '" class="results-table__results__image" />'
               },
               {
-                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to Overnights (due to return)', returnPathWithSort, prisoner.prisonerNumber, '') ~ '" class="govuk-link">' ~ prisonerName ~ '</a>',
+                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to In Reception', returnPathWithSort, prisoner.prisonerNumber, '') ~ '" class="govuk-link">' ~ prisonerName ~ '</a>',
                 sortValue: prisonerName,
                 attributes: {
                 "data-sort-value": prisoner.lastName.toLowerCase() if prisoner.displayName else ''
@@ -68,7 +68,7 @@
                 text: prisoner.from
               },
               {
-                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to Overnights (due to return)', returnPathWithSort, prisoner.prisonerNumber, '/csra-history') ~ '" class="govuk-link">' ~ csraLevel ~ '</a>',
+                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to In Reception', returnPathWithSort, prisoner.prisonerNumber, '/csra-history') ~ '" class="govuk-link">' ~ csraLevel ~ '</a>',
                 sortValue: csraLevel
               },
               {
@@ -81,10 +81,10 @@
           {{ pagination(currentPage, totalPages, paginationBase, totalResults, envPageSize) }}
 
           {{ govukTable({
-            caption: 'Overnights due to return (column headers with buttons are sortable)',
+            caption: 'In Reception (column headers with buttons are sortable)',
             captionClasses: 'govuk-visually-hidden',
             firstCellIsHeader: false,
-            classes: 'govuk-table sortable-table govuk-!-font-size-16',
+            classes: 'govuk-table in-reception-roll__table sortable-table govuk-!-font-size-16',
             head: [
               {
                 text: '',
@@ -94,7 +94,7 @@
               },
               {
                 text: "Name",
-                key: 'lastName',
+                key: 'prisonerName',
                 classes: 'govuk-!-font-size-16'
               },
               {

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -1,4 +1,5 @@
 {% extends "../partials/layout.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "../macros/alertFlags.njk" import alertFlags %}
 {% from "../macros/categoryFlag.njk" import categoryFlag %}
 {% from "../macros/pagination.njk" import pagination %}
@@ -25,49 +26,109 @@
 
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
         <div class="govuk-grid-column-full results-table results-table__results govuk-!-margin-top-2">
-          {% set paginationBase = '/in-reception' %}
+          {% set sortParam = sort or 'prisonerName&direction=ascending' %}
+          {% set paginationBase = '/in-reception?sort=' ~ sortParam %}
           {% set pageParam = '?page=' ~ currentPage if currentPage > 1 else '' %}
-          {% set returnPathWithPage = '/in-reception' ~ pageParam %}
+          {% set returnPathWithSort = paginationBase ~ pageParam %}
+          {% set rows = [] %}
+          {% set blankRows = [
+            [
+              {
+                html: 'No people to display',
+                colspan: 8
+              }
+            ]
+          ] %}
+          {% for prisoner in prisoners %}
+            {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
+            {% set csraLevel = prisoner.csra or 'None' %}
+            {% set rows = (rows.push([
+              {
+                html: '<img src="/prisonerImage/' ~ (prisoner.prisonerNumber or 'placeholder') ~ '" alt="Image of ' ~ prisonerName ~ '" class="results-table__results__image" />'
+              },
+              {
+                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to Overnights (due to return)', returnPathWithSort, prisoner.prisonerNumber, '') ~ '" class="govuk-link">' ~ prisonerName ~ '</a>',
+                sortValue: prisonerName,
+                attributes: {
+                "data-sort-value": prisoner.lastName.toLowerCase() if prisoner.displayName else ''
+              }
+              },
+              {
+                text: prisoner.prisonerNumber
+              },
+              {
+                text: prisoner.dateOfBirth | formatDate('medium'),
+                sortValue: prisoner.dateOfBirth | toUnixTimeStamp()
+              },
+              {
+                text: prisoner.timeArrived | formatTime,
+                sortValue: prisoner.timeArrived | toUnixTimeStamp()
+              },
+              {
+                text: prisoner.from
+              },
+              {
+                html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to Overnights (due to return)', returnPathWithSort, prisoner.prisonerNumber, '/csra-history') ~ '" class="govuk-link">' ~ csraLevel ~ '</a>',
+                sortValue: csraLevel
+              },
+              {
+                html: alertFlags(prisoner.alertFlags) ~ categoryFlag("", prisoner.category) | safe
+              }
+            ]), rows) %}
+
+          {% endfor %}
+
           {{ pagination(currentPage, totalPages, paginationBase, totalResults, envPageSize) }}
 
-            <table class="govuk-table in-reception-roll__table" data-module="moj-sortable-table">
-                <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Picture</span></th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="ascending">Name</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Prison number</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Date of birth</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">Time arrived</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Arrived from</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16" aria-sort="none">CSRA</th>
-                        <th scope="col" class="govuk-table__header govuk-!-font-size-16">Relevant alerts</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                {% if prisoners.length > 0 %}
-                    {% for prisoner in prisoners %}
-                        {% set prisonerName = prisoner.firstName | formatName("", prisoner.lastName, { style: 'lastCommaFirst' }) %}
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell"><img src="/prisonerImage/{{ prisoner.prisonerNumber or 'placeholder' }}" alt="Image of {{ prisonerName }}" class="results-table__results__image" /></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisonerName }}" ><a href="{{ prisonerProfileBackLinkUrl('Back to In reception', returnPathWithPage, prisoner.prisonerNumber) }}" class="govuk-link">{{ prisonerName }}</a></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.prisonerNumber }}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ prisoner.dateOfBirth }}">{{ prisoner.dateOfBirth | formatDate('short')}}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.timeArrived | formatTime }}</td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ prisoner.from }}</td>
-                            {% set csraLevel = prisoner.csra or 'None' %}
-                            <td class="govuk-table__cell govuk-!-font-size-16" data-sort-value="{{ csraLevel }}"><a href="{{ prisonerProfileBackLinkUrl('Back to In reception', returnPathWithPage, prisoner.prisonerNumber, '/csra-history') }}" class="govuk-link">{{ csraLevel }}</a></td>
-                            <td class="govuk-table__cell govuk-!-font-size-16">{{ alertFlags(prisoner.alertFlags) if prisoner.alertFlags | length else "No relevant alerts" }}{{categoryFlag("", prisoner.category) | safe}}</td>
-                        </tr>
-                    {% endfor %}
-                {% else %}
-                  <tr class="govuk-table__row">
-                    <td class="govuk-table__cell--tall" colspan="7">No people to display</td>
-                  </tr>
-                {% endif %}
-                </tbody>
-            </table>
+          {{ govukTable({
+            caption: 'Overnights due to return (column headers with buttons are sortable)',
+            captionClasses: 'govuk-visually-hidden',
+            firstCellIsHeader: false,
+            classes: 'govuk-table sortable-table govuk-!-font-size-16',
+            head: [
+              {
+                text: '',
+                attributes: {
+                  width: '100px'
+                }
+              },
+              {
+                text: "Name",
+                key: 'lastName',
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: "Prison number",
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: "Date of birth",
+                key: 'dateOfBirth',
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: 'Time arrived',
+                key: 'timeArrived',
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: 'Arrived from',
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: 'CSRA',
+                key: 'csra',
+                classes: 'govuk-!-font-size-16'
+              },
+              {
+                text: 'Relevant alerts',
+                classes: 'govuk-!-font-size-16'
+              }
+            ] | convertToSortableColumns(sortParam, '?sort={sortKey}&direction={sortDirection}'),
+            rows: rows if prisoners.length > 0 else blankRows
+          }) }}
 
-          {{ pagination(currentPage, totalPages, paginationBase, totalResults, pageSize) }}
+          {{ pagination(currentPage, totalPages, paginationBase, totalResults, envPageSize) }}
         </div>
     </div>
 </div>

--- a/server/views/pages/inReception.njk
+++ b/server/views/pages/inReception.njk
@@ -50,19 +50,25 @@
                 html: '<a href="' ~ prisonerProfileBackLinkUrl('Back to In Reception', returnPathWithSort, prisoner.prisonerNumber, '') ~ '" class="govuk-link">' ~ prisonerName ~ '</a>',
                 sortValue: prisonerName,
                 attributes: {
-                "data-sort-value": prisoner.lastName.toLowerCase() if prisoner.displayName else ''
-              }
+                  "data-sort-value": prisoner.lastName.toLowerCase() if prisoner.displayName else ''
+                }
               },
               {
                 text: prisoner.prisonerNumber
               },
               {
                 text: prisoner.dateOfBirth | formatDate('medium'),
-                sortValue: prisoner.dateOfBirth | toUnixTimeStamp()
+                sortValue: prisoner.dateOfBirth | toUnixTimeStamp(),
+                attributes: {
+                  "data-sort-value": prisoner.dateOfBirth
+                }
               },
               {
                 text: prisoner.timeArrived | formatTime,
-                sortValue: prisoner.timeArrived | toUnixTimeStamp()
+                sortValue: prisoner.timeArrived | toUnixTimeStamp(),
+                attributes: {
+                  "data-sort-value": prisoner.timeArrived | formatTime
+                }
               },
               {
                 text: prisoner.from


### PR DESCRIPTION
## Description

'In Reception' page restructured to use the govukTable component. This enables default and custom sorting on the page controlled by both the table headers and the URL parameters. The 'In Reception' table data can now be sorted in the following columns:

- Name 
- Date of Birth
- Time arrived
- CSRA

Table is sorted by Name (Surname, First name) ascending by default. 

## Jira ticket

[MAPB-204](https://dsdmoj.atlassian.net/browse/MAPB-204)



[MAPB-204]: https://dsdmoj.atlassian.net/browse/MAPB-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ